### PR TITLE
store u2f master in eeprom

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -290,7 +290,7 @@ int commander_fill_signature_array(const uint8_t sig[64], const uint8_t pubkey[3
 
 void commander_force_reset(void)
 {
-    memory_erase();
+    memory_reset_hww();
     commander_clear_report();
     commander_fill_report(cmd_str(CMD_reset), NULL, DBB_ERR_IO_RESET);
 }
@@ -311,7 +311,7 @@ static void commander_process_reset(yajl_val json_node)
         return;
     }
 
-    memory_erase();
+    memory_reset_hww();
     commander_clear_report();
     commander_fill_report(cmd_str(CMD_reset), attr_str(ATTR_success), DBB_OK);
 }
@@ -350,7 +350,7 @@ static int commander_process_backup_check(const char *key, const char *filename)
         if (!memcmp(backup, MEM_PAGE_ERASE, MEM_PAGE_LEN)) {
             commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
             ret = DBB_ERROR;
-        } else if (memcmp(backup, memory_master_entropy(NULL), MEM_PAGE_LEN)) {
+        } else if (memcmp(backup, memory_master_hww_entropy(NULL), MEM_PAGE_LEN)) {
             commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
             ret = DBB_ERROR;
         } else {
@@ -388,7 +388,7 @@ static int commander_process_backup_create(const char *key, const char *filename
     char backup_hex[MEM_PAGE_LEN * 2 + 1];
     char *name = (char *)memory_name("");
 
-    memcpy(backup, memory_master_entropy(NULL), MEM_PAGE_LEN);
+    memcpy(backup, memory_master_hww_entropy(NULL), MEM_PAGE_LEN);
 
     if (!memcmp(backup, MEM_PAGE_ERASE, MEM_PAGE_LEN)) {
         commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_KEY_MASTER);
@@ -560,7 +560,7 @@ static void commander_process_seed(yajl_val json_node)
         ret = wallet_generate_master(key, entropy_c);
         if (ret == DBB_OK) {
             if (commander_process_backup_create(key, filename) != DBB_OK) {
-                memory_erase_seed();
+                memory_erase_hww_seed();
                 return;
             }
         }

--- a/src/commander.c
+++ b/src/commander.c
@@ -1199,7 +1199,7 @@ static void commander_process_password(yajl_val json_node, int cmd, PASSWORD_ID 
 
     if (!memcmp(memory_report_aeskey(PASSWORD_STAND), memory_report_aeskey(PASSWORD_HIDDEN),
                 MEM_PAGE_LEN)) {
-        memory_erase_hidden_password();
+        memory_random_password(PASSWORD_HIDDEN);
         commander_fill_report(cmd_str(CMD_password), NULL, DBB_ERR_IO_PW_COLLIDE);
         return;
     }

--- a/src/memory.c
+++ b/src/memory.c
@@ -83,17 +83,6 @@ static void memory_mempass(void)
 }
 
 
-static void memory_create_verifypass(void)
-{
-    uint8_t number[16] = {0};
-    random_bytes(number, sizeof(number), 0);
-    memory_write_aeskey(utils_uint8_to_hex(number, sizeof(number)), sizeof(number) * 2,
-                        PASSWORD_VERIFY);
-    utils_zero(number, sizeof(number));
-    utils_clear_buffers();
-}
-
-
 static int memory_eeprom(uint8_t *write_b, uint8_t *read_b, const int32_t addr,
                          const uint16_t len)
 {
@@ -257,10 +246,10 @@ void memory_erase_seed(void)
 void memory_erase(void)
 {
     memory_mempass();
-    memory_create_verifypass();
-    memory_erase_hidden_password();
-    memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND);
+    memory_random_password(PASSWORD_VERIFY);
+    memory_random_password(PASSWORD_HIDDEN);
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
+    memory_random_password(PASSWORD_STAND);
     memory_erase_seed();
     memory_name(DEVICE_DEFAULT_NAME);
     memory_write_erased(DEFAULT_erased);
@@ -271,12 +260,13 @@ void memory_erase(void)
 }
 
 
-void memory_erase_hidden_password(void)
+void memory_random_password(PASSWORD_ID id)
 {
     uint8_t number[16] = {0};
     random_bytes(number, sizeof(number), 0);
-    memory_write_aeskey(utils_uint8_to_hex(number, sizeof(number)), sizeof(number) * 2,
-                        PASSWORD_HIDDEN);
+    memory_write_aeskey(utils_uint8_to_hex(number, sizeof(number)), sizeof(number) * 2, id);
+    utils_zero(number, sizeof(number));
+    utils_clear_buffers();
 }
 
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -77,7 +77,7 @@ typedef enum PASSWORD_ID {
 int memory_setup(void);
 void memory_erase(void);
 void memory_erase_seed(void);
-void memory_erase_hidden_password(void);
+void memory_random_password(PASSWORD_ID id);
 void memory_clear(void);
 
 int memory_aeskey_is_erased(PASSWORD_ID id);

--- a/src/memory.h
+++ b/src/memory.h
@@ -42,7 +42,7 @@
 #define MEM_UNLOCKED_ADDR               0x0008
 #define MEM_EXT_FLAGS_ADDR              0x000A// (uint32_t) 32 possible extension flags
 #define MEM_U2F_COUNT_ADDR              0x0010// (uint32_t)
-#define MEM_NAME_ADDR                   0x0100// Zone 1
+#define MEM_NAME_ADDR                   0x0100// (32 bytes) Zone 1
 #define MEM_MASTER_BIP32_ADDR           0x0200
 #define MEM_MASTER_BIP32_CHAIN_ADDR     0x0300
 #define MEM_AESKEY_STAND_ADDR           0x0400
@@ -50,6 +50,7 @@
 #define MEM_AESKEY_CRYPT_ADDR           0x0600
 #define MEM_AESKEY_HIDDEN_ADDR          0x0800// Zone 7 reserved
 #define MEM_MASTER_ENTROPY_ADDR         0x0900
+#define MEM_MASTER_U2F_ADDR             0x0A00
 
 
 // Extension flags
@@ -75,8 +76,9 @@ typedef enum PASSWORD_ID {
 
 
 int memory_setup(void);
-void memory_erase(void);
-void memory_erase_seed(void);
+void memory_reset_u2f(void);
+void memory_reset_hww(void);
+void memory_erase_hww_seed(void);
 void memory_random_password(PASSWORD_ID id);
 void memory_clear(void);
 
@@ -84,10 +86,11 @@ int memory_aeskey_is_erased(PASSWORD_ID id);
 int memory_write_aeskey(const char *password, int len, PASSWORD_ID id);
 uint8_t *memory_report_aeskey(PASSWORD_ID id);
 uint8_t *memory_name(const char *name);
-uint8_t *memory_master(const uint8_t *master_priv_key);
-uint8_t *memory_chaincode(const uint8_t *chain_code);
-uint8_t *memory_master_entropy(const uint8_t *master_entropy);
-uint8_t *memory_master_u2f(void);
+uint8_t *memory_master_hww(const uint8_t *master_priv_key);
+uint8_t *memory_master_hww_chaincode(const uint8_t *chain_code);
+uint8_t *memory_master_hww_entropy(const uint8_t *master_entropy);
+uint8_t *memory_master_u2f(const uint8_t *master_u2f);
+uint8_t *memory_report_master_u2f(void);
 
 uint8_t *memory_read_memseed(void);
 uint8_t memory_read_erased(void);

--- a/src/u2f_device.c
+++ b/src/u2f_device.c
@@ -146,7 +146,7 @@ static void u2f_keyhandle_gen(const uint8_t *appId, uint8_t *nonce, uint8_t *pri
 {
     uint8_t hash[SHA256_DIGEST_LENGTH];
     for (;;) {
-        hmac_sha256(appId, U2F_APPID_SIZE, memory_master_u2f(), 32, hash);
+        hmac_sha256(appId, U2F_APPID_SIZE, memory_report_master_u2f(), 32, hash);
         hmac_sha256(hash, SHA256_DIGEST_LENGTH, nonce, U2F_NONCE_LENGTH, privkey);
         hmac_sha256(hash, SHA256_DIGEST_LENGTH, privkey, U2F_EC_KEY_SIZE, mac);
 

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -71,9 +71,9 @@ int wallet_is_locked(void)
 uint8_t *wallet_get_master(void)
 {
     if (HIDDEN) {
-        return memory_chaincode(NULL);
+        return memory_master_hww_chaincode(NULL);
     } else {
-        return memory_master(NULL);
+        return memory_master_hww(NULL);
     }
 }
 
@@ -81,17 +81,17 @@ uint8_t *wallet_get_master(void)
 uint8_t *wallet_get_chaincode(void)
 {
     if (HIDDEN) {
-        return memory_master(NULL);
+        return memory_master_hww(NULL);
     } else {
-        return memory_chaincode(NULL);
+        return memory_master_hww_chaincode(NULL);
     }
 }
 
 
 int wallet_seeded(void)
 {
-    if (!memcmp(memory_master(NULL), MEM_PAGE_ERASE, 32)  ||
-            !memcmp(memory_chaincode(NULL), MEM_PAGE_ERASE, 32)) {
+    if (!memcmp(memory_master_hww(NULL), MEM_PAGE_ERASE, 32)  ||
+            !memcmp(memory_master_hww_chaincode(NULL), MEM_PAGE_ERASE, 32)) {
         return DBB_ERROR;
     } else {
         return DBB_OK;
@@ -129,9 +129,10 @@ int wallet_generate_master(const char *passphrase, const char *entropy_in)
 
     memcpy(entropy, utils_hex_to_uint8(entropy_in), sizeof(entropy));
 
-    memory_master(node.private_key);
-    memory_chaincode(node.chain_code);
-    memory_master_entropy(entropy);
+    memory_master_hww(node.private_key);
+    memory_master_hww_chaincode(node.chain_code);
+    memory_master_hww_entropy(entropy);
+    memory_master_u2f(node.chain_code);// TODO - make independent of hww seed
 
     ret = wallet_seeded();
     if (ret != DBB_OK) {


### PR DESCRIPTION
Prerequisite before making the U2F master key independent of the HWW seed.

As a throw-in commit, randomizing the device password instead of zeroing adds a small security improvement.